### PR TITLE
Fix percentage formatting for unity decimals

### DIFF
--- a/app/utils/excel/formatters.py
+++ b/app/utils/excel/formatters.py
@@ -84,10 +84,11 @@ class ExcelFormatter:
         
         try:
             numeric_value = float(value)
-            if as_decimal and numeric_value > 1:
-                # Assume it's a percentage and convert to decimal
-                return numeric_value / 100
-            return numeric_value
+            if as_decimal:
+                # When exporting as decimal, treat values >=1 as percentages
+                return numeric_value / 100 if numeric_value >= 1 else numeric_value
+            # Otherwise ensure decimal inputs (0-1) are converted to percentage scale
+            return numeric_value * 100 if numeric_value <= 1 else numeric_value
         except (TypeError, ValueError):
             return None
     

--- a/app/utils/pricing_transformer.py
+++ b/app/utils/pricing_transformer.py
@@ -46,7 +46,8 @@ class PricingTransformer:
         def format_percentage(value: Any) -> float:
             try:
                 numeric_value = float(value)
-                return numeric_value * 100 if numeric_value < 1 else numeric_value
+                # Treat 1 (100%) as a decimal that needs conversion
+                return numeric_value * 100 if numeric_value <= 1 else numeric_value
             except (TypeError, ValueError):
                 return 0.0
 


### PR DESCRIPTION
## Summary
- treat value 1.0 as 100% in pricing transformer percentage normalization
- adjust Excel formatter to convert percentages symmetrically for decimal and percentage inputs

## Testing
- `pytest tests/test_api_endpoints.py::TestHealthAndBasic::test_health_endpoint -q` *(fails: httpx.ConnectError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c1828c932883229b2249f787415342